### PR TITLE
Use original fg/bg intensity values on reset

### DIFF
--- a/ansicolor_windows.go
+++ b/ansicolor_windows.go
@@ -225,8 +225,8 @@ func changeColor(param []byte) {
 			case ansiReset:
 				winAttr.foregroundColor = defaultAttr.foregroundColor
 				winAttr.backgroundColor = defaultAttr.backgroundColor
-				winAttr.foregroundIntensity = 0
-				winAttr.backgroundIntensity = 0
+				winAttr.foregroundIntensity = defaultAttr.foregroundIntensity
+				winAttr.backgroundIntensity = defaultAttr.backgroundIntensity
 				winAttr.underscore = 0
 				winAttr.otherAttributes = 0
 			case ansiIntensityOn:

--- a/ansicolor_windows_test.go
+++ b/ansicolor_windows_test.go
@@ -60,6 +60,8 @@ func TestWriteAnsiColorText(t *testing.T) {
 	defer ChangeColor(screenInfo.WAttributes)
 	defaultFgColor := screenInfo.WAttributes & uint16(0x0007)
 	defaultBgColor := screenInfo.WAttributes & uint16(0x0070)
+	defaultFgIntensity := screenInfo.WAttributes & uint16(0x0008)
+	defaultBgIntensity := screenInfo.WAttributes & uint16(0x0080)
 
 	fgParam := []testParam{
 		{"foreground black  ", uint16(0x0000 | 0x0000), "30"},
@@ -86,8 +88,8 @@ func TestWriteAnsiColorText(t *testing.T) {
 	}
 
 	resetParam := []testParam{
-		{"all reset", defaultFgColor | defaultBgColor, "0"},
-		{"all reset", defaultFgColor | defaultBgColor, ""},
+		{"all reset", defaultFgColor | defaultBgColor | defaultFgIntensity | defaultBgIntensity, "0"},
+		{"all reset", defaultFgColor | defaultBgColor | defaultFgIntensity | defaultBgIntensity, ""},
 	}
 
 	boldParam := []testParam{


### PR DESCRIPTION
There is a problem when the ForegroundIntensity and BackgroundIntensity are set to 0 when resetting using "\x1b[0m". If the foreground or background color was one of the bold colors, it was reset to the non-bold version of that color.

I see commit 91b6880597975e6c79bfe991875015423d0384f1 had originally changed this along with the underScore and otherAttributes. I'm not sure of the reason for this change but I wonder if the intensity values shouldn't have been removed with the other attributes. Let me know what you think. I also updated the test to include the intensity values on the reset test.

This is what I see when running the example. My background color is the gray which is the bolded version of black. When the reset happens, it is reset to black instead of gray. It continues on like this until I run "color" to reset the colors and then clear the screen.
![image](https://cloud.githubusercontent.com/assets/315862/3122502/d5d43d2a-e767-11e3-83f6-557758fd397b.png)

This is the color palette for my cmd prompt:
![image](https://cloud.githubusercontent.com/assets/315862/3122506/ead32a06-e767-11e3-8df7-2c0d5535c7f5.png)

Thanks for your library. I was using ansicon to get colors in the_platinum_searcher but this is much better.
