### PR TITLE
(refs #7) Output unknown esc code

### DIFF
--- a/ansicolor.go
+++ b/ansicolor.go
@@ -7,14 +7,36 @@ package ansicolor
 
 import "io"
 
+type outputMode int
+
+// DiscardNonColorEscSeq supports the divided color escape sequence.
+// But non-color escape sequence is not output.
+// Please use the OutputNonColorEscSeq If you want to output a non-color
+// escape sequences such as ncurses. However, it does not support the divided
+// color escape sequence.
+const (
+	_ outputMode = iota
+	DiscardNonColorEscSeq
+	OutputNonColorEscSeq
+)
+
 // NewAnsiColorWriter creates and initializes a new ansiColorWriter
 // using io.Writer w as its initial contents.
 // In the console of Windows, which change the foreground and background
 // colors of the text by the escape sequence.
 // In the console of other systems, which writes to w all text.
 func NewAnsiColorWriter(w io.Writer) io.Writer {
+	return NewModeAnsiColorWriter(w, DiscardNonColorEscSeq)
+}
+
+// NewModeAnsiColorWriter create and initializes a new ansiColorWriter
+// by specifying the outputMode.
+func NewModeAnsiColorWriter(w io.Writer, mode outputMode) io.Writer {
 	if _, ok := w.(*ansiColorWriter); !ok {
-		return &ansiColorWriter{w: w}
+		return &ansiColorWriter{
+			w:    w,
+			mode: mode,
+		}
 	}
 	return w
 }

--- a/ansicolor_ansi.go
+++ b/ansicolor_ansi.go
@@ -9,7 +9,8 @@ package ansicolor
 import "io"
 
 type ansiColorWriter struct {
-	w io.Writer
+	w    io.Writer
+	mode outputMode
 }
 
 func (cw *ansiColorWriter) Write(p []byte) (int, error) {

--- a/ansicolor_windows_test.go
+++ b/ansicolor_windows_test.go
@@ -237,7 +237,7 @@ func TestWriteAnsiColorText(t *testing.T) {
 
 func TestIgnoreUnknownSequences(t *testing.T) {
 	inner := bytes.NewBufferString("")
-	w := ansicolor.NewAnsiColorWriter(inner)
+	w := ansicolor.NewModeAnsiColorWriter(inner, ansicolor.OutputNonColorEscSeq)
 
 	inputText := "\x1b[=decpath mode"
 	expectedTail := inputText

--- a/ansicolor_windows_test.go
+++ b/ansicolor_windows_test.go
@@ -23,7 +23,7 @@ func TestWritePlanText(t *testing.T) {
 	fmt.Fprintf(w, expected)
 	actual := inner.String()
 	if actual != expected {
-		t.Errorf("Get %s, want %s", actual, expected)
+		t.Errorf("Get %q, want %q", actual, expected)
 	}
 }
 
@@ -37,7 +37,7 @@ func TestWriteParseText(t *testing.T) {
 	actualTail := inner.String()
 	inner.Reset()
 	if actualTail != expectedTail {
-		t.Errorf("Get %s, want %s", actualTail, expectedTail)
+		t.Errorf("Get %q, want %q", actualTail, expectedTail)
 	}
 
 	inputHead := "head text\x1b[0m"
@@ -46,7 +46,7 @@ func TestWriteParseText(t *testing.T) {
 	actualHead := inner.String()
 	inner.Reset()
 	if actualHead != expectedHead {
-		t.Errorf("Get %s, want %s", actualHead, expectedHead)
+		t.Errorf("Get %q, want %q", actualHead, expectedHead)
 	}
 
 	inputBothEnds := "both ends \x1b[0m text"
@@ -55,7 +55,7 @@ func TestWriteParseText(t *testing.T) {
 	actualBothEnds := inner.String()
 	inner.Reset()
 	if actualBothEnds != expectedBothEnds {
-		t.Errorf("Get %s, want %s", actualBothEnds, expectedBothEnds)
+		t.Errorf("Get %q, want %q", actualBothEnds, expectedBothEnds)
 	}
 
 	inputManyEsc := "\x1b\x1b\x1b\x1b[0m many esc"
@@ -64,7 +64,7 @@ func TestWriteParseText(t *testing.T) {
 	actualManyEsc := inner.String()
 	inner.Reset()
 	if actualManyEsc != expectedManyEsc {
-		t.Errorf("Get %s, want %s", actualManyEsc, expectedManyEsc)
+		t.Errorf("Get %q, want %q", actualManyEsc, expectedManyEsc)
 	}
 
 	expectedSplit := "split  text"
@@ -74,7 +74,7 @@ func TestWriteParseText(t *testing.T) {
 	actualSplit := inner.String()
 	inner.Reset()
 	if actualSplit != expectedSplit {
-		t.Errorf("Get %s, want %s", actualSplit, expectedSplit)
+		t.Errorf("Get %q, want %q", actualSplit, expectedSplit)
 	}
 }
 
@@ -189,13 +189,13 @@ func TestWriteAnsiColorText(t *testing.T) {
 	assertTextAttribute := func(expectedText string, expectedAttributes uint16, ansiColor string) {
 		actualText, actualAttributes, err := writeAnsiColor(expectedText, ansiColor)
 		if actualText != expectedText {
-			t.Errorf("Get %s, want %s", actualText, expectedText)
+			t.Errorf("Get %q, want %q", actualText, expectedText)
 		}
 		if err != nil {
 			t.Fatal("Could not get ConsoleScreenBufferInfo")
 		}
 		if actualAttributes != expectedAttributes {
-			t.Errorf("Text: %s, Get 0x%04x, want 0x%04x", expectedText, actualAttributes, expectedAttributes)
+			t.Errorf("Text: %q, Get 0x%04x, want 0x%04x", expectedText, actualAttributes, expectedAttributes)
 		}
 	}
 
@@ -245,7 +245,7 @@ func TestIgnoreUnknownSequences(t *testing.T) {
 	actualTail := inner.String()
 	inner.Reset()
 	if actualTail != expectedTail {
-		t.Errorf("Get %s, want %s", actualTail, expectedTail)
+		t.Errorf("Get %q, want %q", actualTail, expectedTail)
 	}
 
 	inputText = "\x1b[=tailing esc and bracket\x1b["
@@ -254,7 +254,7 @@ func TestIgnoreUnknownSequences(t *testing.T) {
 	actualTail = inner.String()
 	inner.Reset()
 	if actualTail != expectedTail {
-		t.Errorf("Get %s, want %s", actualTail, expectedTail)
+		t.Errorf("Get %q, want %q", actualTail, expectedTail)
 	}
 
 	inputText = "\x1b[?tailing esc\x1b"
@@ -263,7 +263,7 @@ func TestIgnoreUnknownSequences(t *testing.T) {
 	actualTail = inner.String()
 	inner.Reset()
 	if actualTail != expectedTail {
-		t.Errorf("Get %s, want %s", actualTail, expectedTail)
+		t.Errorf("Get %q, want %q", actualTail, expectedTail)
 	}
 
 	inputText = "\x1b[1h;3punended color code invalid\x1b3"
@@ -272,6 +272,6 @@ func TestIgnoreUnknownSequences(t *testing.T) {
 	actualTail = inner.String()
 	inner.Reset()
 	if actualTail != expectedTail {
-		t.Errorf("Get %s, want %s", actualTail, expectedTail)
+		t.Errorf("Get %q, want %q", actualTail, expectedTail)
 	}
 }

--- a/ansicolor_windows_test.go
+++ b/ansicolor_windows_test.go
@@ -234,3 +234,44 @@ func TestWriteAnsiColorText(t *testing.T) {
 		assertTextAttribute(v.text, v.attributes, v.ansiColor)
 	}
 }
+
+func TestIgnoreUnknownSequences(t *testing.T) {
+	inner := bytes.NewBufferString("")
+	w := ansicolor.NewAnsiColorWriter(inner)
+
+	inputText := "\x1b[=decpath mode"
+	expectedTail := inputText
+	fmt.Fprintf(w, inputText)
+	actualTail := inner.String()
+	inner.Reset()
+	if actualTail != expectedTail {
+		t.Errorf("Get %s, want %s", actualTail, expectedTail)
+	}
+
+	inputText = "\x1b[=tailing esc and bracket\x1b["
+	expectedTail = inputText
+	fmt.Fprintf(w, inputText)
+	actualTail = inner.String()
+	inner.Reset()
+	if actualTail != expectedTail {
+		t.Errorf("Get %s, want %s", actualTail, expectedTail)
+	}
+
+	inputText = "\x1b[?tailing esc\x1b"
+	expectedTail = inputText
+	fmt.Fprintf(w, inputText)
+	actualTail = inner.String()
+	inner.Reset()
+	if actualTail != expectedTail {
+		t.Errorf("Get %s, want %s", actualTail, expectedTail)
+	}
+
+	inputText = "\x1b[1h;3punended color code invalid\x1b3"
+	expectedTail = inputText
+	fmt.Fprintf(w, inputText)
+	actualTail = inner.String()
+	inner.Reset()
+	if actualTail != expectedTail {
+		t.Errorf("Get %s, want %s", actualTail, expectedTail)
+	}
+}


### PR DESCRIPTION
ansicolor compatibility will be lost when the output of the unknown escape sequence.
For that reason, I've prepared two modes.

`DiscardNonColorEscSeq` is the same output as before.
`OutputNonColorEscSeq` outputs the unknown escape sequence, but does not support the divided escape sequence as shown in the following test case.
https://github.com/shiena/ansicolor/blob/unknown_esc_code/ansicolor_windows_test.go#L70
